### PR TITLE
NDS-292: iRODS server can't federate with two nodes with same zone

### DIFF
--- a/gobuild.sh
+++ b/gobuild.sh
@@ -2,4 +2,4 @@
 
 cd /go/src/github.com/ndslabs-irods-federate
 go get
-GOOS=linux GOARCH=amd64 go build -o build/bin/amd64/ndslabs-irods-federate
+GOOS=linux GOARCH=amd64 go build -o build/bin/ndslabs-irods-federate-linux-amd64

--- a/test/federation-new.json
+++ b/test/federation-new.json
@@ -1,0 +1,10 @@
+{
+   "user":"dataverse",
+   "icat_address":"172.16.4.6",
+   "federation" : {
+        "icat_host":"samdaq-dvicat-new",
+        "zone_name":"zoneNew",
+        "negotiation_key":"ZZ6A1PPHzeHST1azY73dtkDe70mJVAWa",
+        "zone_key":"eSc99JIAem_rAHFo"
+   }
+}

--- a/test/federation-update.json
+++ b/test/federation-update.json
@@ -1,0 +1,10 @@
+{
+   "user":"dataverse",
+   "icat_address":"172.16.4.6",
+   "federation" : {
+        "icat_host":"samdaq-dvicat-2",
+        "zone_name":"zone1",
+        "negotiation_key":"ZZ6A1PPHzeHST1azY73dtkDe70mJVAWa",
+        "zone_key":"eSc99JIAem_rAHFo"
+   }
+}

--- a/test/federation.json
+++ b/test/federation.json
@@ -1,0 +1,10 @@
+{
+   "user":"dataverse",
+   "icat_address":"172.16.4.6",
+   "federation" : {
+        "icat_host":"samdaq-dvicat-1",
+        "zone_name":"zone1",
+        "negotiation_key":"ZZ6A1PPHzeHST1azY73dtkDe70mJVAWa",
+        "zone_key":"eSc99JIAem_rAHFo"
+   }
+}


### PR DESCRIPTION
- Modified the ndslabs-irods-federate service to update an existing federation configuration based on hostname and zone.   Apparently, iRods cannot support federating with two servers with the same zone.
